### PR TITLE
Use standard POSIX sed for better Mac compatibility

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -264,7 +264,7 @@ function prompt_perl -d "Show perl environment"
   test "$BULLETTRAIN_PERL_SHOW" = "true"; or return
 
   test (command -v plenv);
-    and set -l _version $BULLETTRAIN_PERL_PREFIX (plenv version | sed -e 's/ (set.*$//');
+    and set -l _version $BULLETTRAIN_PERL_PREFIX (plenv version | sed 's/ (set.*$//');
       and prompt_segment $BULLETTRAIN_PERL_BG $BULLETTRAIN_PERL_FG "$_version"
 end
 
@@ -273,8 +273,8 @@ function prompt_ruby -d "Show ruby environment"
 
   set -l _ruby_prompt
   if test (command -v rbenv)
-    set -l _version (rbenv version | sed -e 's/ (set.*$//')
-    set -l _gemset (rbenv gemset active ^ /dev/null | sed -e 's/ global$//')
+    set -l _version (rbenv version | sed 's/ (set.*$//')
+    set -l _gemset (rbenv gemset active ^ /dev/null | sed 's/ global$//')
     test "$_gemset";
       and set _ruby_prompt $_version"@"$_gemset;
       or  set _ruby_prompt $_version
@@ -283,7 +283,7 @@ function prompt_ruby -d "Show ruby environment"
   else if test (command -v chruby)
     set _ruby_prompt (chruby | sed -n -e 's/ \* //p')
   else if test (command -v asdf)
-    set _ruby_prompt (asdf current ruby | sed -e 's/\s*(set.*$//')
+    set _ruby_prompt (asdf current ruby | sed 's/[[:space:]]*(set.*$//')
   end
 
   switch "$_ruby_prompt"
@@ -303,9 +303,9 @@ function prompt_python -d "Show python environment"
   if test "$VIRTUAL_ENV" -a "$VIRTUAL_ENV_DISABLE_PROMPT" = "true"
     set _python_prompt (basename $VIRTUAL_ENV)
   else if test (command -v pyenv)
-    set _python_prompt (pyenv version-name | sed -e 's/:.*$//' )
+    set _python_prompt (pyenv version-name | sed 's/:.*$//' )
   else if test (command -v asdf)
-    set _python_prompt (asdf current python | sed -e 's/\s*(set.*$//')
+    set _python_prompt (asdf current python | sed 's/[[:space:]]*(set.*$//')
   end
 
   switch "$_python_prompt"
@@ -325,7 +325,7 @@ function prompt_nodejs -d "Show node.js environment"
   if test (command -v nvm)
     set _nodejs_prompt (nvm current ^ /dev/null);
   else if test (command -v asdf)
-    set _nodejs_prompt (asdf current nodejs | sed -e 's/\s*(set.*$//')
+    set _nodejs_prompt (asdf current nodejs | sed 's/\s*(set.*$//')
   else if test (command -v node)
     set _nodejs_prompt (node --version ^ /dev/null | tail -n1)
   end
@@ -340,7 +340,7 @@ function prompt_go -d "Show go environment"
 
   set -l _go_prompt
   if test (command -v asdf)
-    set _go_prompt (asdf current golang | sed -e 's/\s*(set.*$//')
+    set _go_prompt (asdf current golang | sed 's/[[:space:]]*(set.*$//')
   else if test (command -v go)
     and set _go_prompt (go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]+')
   end


### PR DESCRIPTION
No need for `-e` option, and use `[[:space:]]` instead of `\s` for whitespace matching